### PR TITLE
fix: fixed HTML to React JSX parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@eslint/js": "^9.11.1",
         "@types/node": "^22.7.3",
+        "@types/prettier": "^2.7.3",
         "@types/react": "^18.3.9",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
@@ -50,6 +51,7 @@
         "eslint-plugin-react-refresh": "^0.4.12",
         "globals": "^15.9.0",
         "postcss": "^8.4.47",
+        "prettier": "^3.6.2",
         "tailwindcss": "^3.4.13",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.7.0",
@@ -3827,6 +3829,13 @@
         "@types/node": "*",
         "xmlbuilder": ">=11.0.1"
       }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.13",
@@ -10288,6 +10297,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proc-log": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
   "devDependencies": {
     "@eslint/js": "^9.11.1",
     "@types/node": "^22.7.3",
+    "@types/prettier": "^2.7.3",
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -130,6 +131,7 @@
     "eslint-plugin-react-refresh": "^0.4.12",
     "globals": "^15.9.0",
     "postcss": "^8.4.47",
+    "prettier": "^3.6.2",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",

--- a/src/features/html-to-jsx/HtmlToJsx.tsx
+++ b/src/features/html-to-jsx/HtmlToJsx.tsx
@@ -1,37 +1,43 @@
-import { useState } from 'react';
-import { ToolCard } from '@/components/ui/tool-card';
-import { SectionHeader } from '@/components/ui/section-header';
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import { Copy, Wand2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { useHtmlToJsx } from './useHtmlToJsx';
+import { useState } from "react";
+import { ToolCard } from "@/components/ui/tool-card";
+import { SectionHeader } from "@/components/ui/section-header";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Copy, Wand2 } from "lucide-react";
+import { toast } from "sonner";
+import { useHtmlToJsx } from "./useHtmlToJsx";
 
 export function HtmlToJsx() {
   const { convertHtmlToJsx } = useHtmlToJsx();
-  const [htmlInput, setHtmlInput] = useState('');
-  const [jsxOutput, setJsxOutput] = useState('');
+  const [htmlInput, setHtmlInput] = useState("");
+  const [jsxOutput, setJsxOutput] = useState("");
+  const [generatedFiles, setGeneratedFiles] = useState<
+    { name: string; type: string; content: string }[]
+  >([]);
 
   const handleConvert = () => {
     const result = convertHtmlToJsx(htmlInput);
-    setJsxOutput(result);
+    setJsxOutput(result.jsx);
+    setGeneratedFiles(result.files);
   };
 
-  const handleCopy = async () => {
+  const handleCopy = async (text: string, label: string) => {
     try {
-      await navigator.clipboard.writeText(jsxOutput);
-      toast.success('JSX copied to clipboard');
-    } catch (err) {
-      toast.error('Failed to copy');
+      await navigator.clipboard.writeText(text);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error("Failed to copy");
     }
   };
 
   const handleClear = () => {
-    setHtmlInput('');
-    setJsxOutput('');
+    setHtmlInput("");
+    setJsxOutput("");
+    setGeneratedFiles([]);
   };
 
-  const sampleHtml = `<div class="container">
+  const sampleHtml = `
+  <div class="container">
   <h1>Welcome to React</h1>
   <p>This is a sample HTML structure.</p>
   <form>
@@ -40,18 +46,20 @@ export function HtmlToJsx() {
     <button type="submit">Submit</button>
   </form>
   <img src="image.jpg" alt="Sample image" />
-</div>`;
+  </div>
+  `;
 
   const handleLoadSample = () => {
     setHtmlInput(sampleHtml);
   };
 
   return (
-    <ToolCard 
-      title="HTML to JSX" 
+    <ToolCard
+      title="HTML to JSX"
       description="Convert HTML markup to React JSX with proper attribute and syntax formatting"
     >
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* HTML Input */}
         <div>
           <SectionHeader title="HTML Input">
             <div className="flex gap-2">
@@ -61,9 +69,12 @@ export function HtmlToJsx() {
               <Button variant="outline" size="sm" onClick={handleClear}>
                 Clear
               </Button>
-              <Button size="sm" onClick={handleConvert} disabled={!htmlInput.trim()}>
-                <Wand2 className="h-4 w-4 mr-2" />
-                Convert
+              <Button
+                size="sm"
+                onClick={handleConvert}
+                disabled={!htmlInput.trim()}
+              >
+                <Wand2 className="h-4 w-4 mr-2" /> Convert
               </Button>
             </div>
           </SectionHeader>
@@ -71,30 +82,61 @@ export function HtmlToJsx() {
             placeholder="Paste your HTML markup here..."
             value={htmlInput}
             onChange={(e) => setHtmlInput(e.target.value)}
-            className="min-h-[400px] font-mono text-sm"
+            className="min-h-[300px] font-mono text-sm"
           />
         </div>
-        
+
+        {/* JSX Output */}
         <div>
           <SectionHeader title="JSX Output">
             <Button
               variant="outline"
               size="sm"
-              onClick={handleCopy}
+              onClick={() => handleCopy(jsxOutput, "JSX")}
               disabled={!jsxOutput}
             >
-              <Copy className="h-4 w-4 mr-2" />
-              Copy
+              <Copy className="h-4 w-4 mr-2" /> Copy
             </Button>
           </SectionHeader>
           <Textarea
             value={jsxOutput}
             readOnly
-            className="min-h-[400px] font-mono text-sm"
+            className="min-h-[300px] font-mono text-sm"
             placeholder="Converted JSX will appear here..."
           />
         </div>
       </div>
+
+      {/* Generated Files */}
+      {generatedFiles.length > 0 && (
+        <div className="mt-6 bg-muted p-4 rounded-lg">
+          <h4 className="font-medium mb-4">Generated Files</h4>
+          <div className="space-y-6">
+            {generatedFiles.map((file, i) => (
+              <div
+                key={i}
+                className="border rounded-lg p-3 bg-background shadow-sm"
+              >
+                <div className="flex justify-between items-center mb-2">
+                  <span className="text-sm font-semibold">{file.name}</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopy(file.content, file.name)}
+                  >
+                    <Copy className="h-4 w-4 mr-2" /> Copy
+                  </Button>
+                </div>
+                <Textarea
+                  value={file.content}
+                  readOnly
+                  className="min-h-[150px] font-mono text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="bg-muted p-4 rounded-lg">
         <h4 className="font-medium mb-2">Conversion Features</h4>
@@ -105,6 +147,10 @@ export function HtmlToJsx() {
           <li>• Preserves HTML structure and formatting</li>
           <li>• Converts inline styles to JSX format</li>
           <li>• Ready to use as React component</li>
+          <li>• Extracts & generates meta tags as separate file</li>
+          <li>• Converts HTML comments to JSX comments</li>
+          <li>• Handles boolean attributes correctly</li>
+          <li>• Removes doctype and unnecessary tags</li>
         </ul>
       </div>
     </ToolCard>

--- a/src/features/html-to-jsx/HtmlToJsx.tsx
+++ b/src/features/html-to-jsx/HtmlToJsx.tsx
@@ -15,8 +15,8 @@ export function HtmlToJsx() {
     { name: string; type: string; content: string }[]
   >([]);
 
-  const handleConvert = () => {
-    const result = convertHtmlToJsx(htmlInput);
+  const handleConvert = async () => {
+    const result = await convertHtmlToJsx(htmlInput);
     setJsxOutput(result.jsx);
     setGeneratedFiles(result.files);
   };

--- a/src/features/html-to-jsx/useHtmlToJsx.ts
+++ b/src/features/html-to-jsx/useHtmlToJsx.ts
@@ -1,118 +1,159 @@
 export function useHtmlToJsx() {
-  const convertHtmlToJsx = (htmlString: string): string => {
+  const validateHtml = (htmlString: string): boolean => {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(htmlString, "text/html");
+      const parseErrors = doc.querySelectorAll("parsererror");
+      return parseErrors.length === 0;
+    } catch {
+      return false;
+    }
+  };
+
+  type GeneratedFile = {
+    name: string;
+    type: "css" | "js" | "meta";
+    content: string;
+  };
+
+  const convertHtmlToJsx = (
+    htmlString: string
+  ): { jsx: string; files: GeneratedFile[] } => {
     if (!htmlString.trim()) {
-      return "";
+      return { jsx: "", files: [] };
+    }
+
+    if (!validateHtml(htmlString)) {
+      return {
+        jsx: "Error: Invalid HTML syntax. Please fix before converting.",
+        files: [],
+      };
     }
 
     try {
       let jsx = htmlString;
+      const imports: string[] = [];
+      const files: GeneratedFile[] = [];
+      let styleCounter = 0;
+      let scriptCounter = 0;
+      let metaContents: string[] = [];
 
-      // Convert class to className
+      // Remove <!DOCTYPE>, <html>, <head>, <body>, <title>
+      jsx = jsx.replace(/<!DOCTYPE[^>]*>/i, "");
+      jsx = jsx.replace(/<\/?(html|head|body|title)[^>]*>/gi, "");
+
+      // Extract <meta> tags (collect all into one)
+      jsx = jsx.replace(/<meta[^>]*>/gi, (match) => {
+        metaContents.push(match);
+        return "";
+      });
+
+      if (metaContents.length > 0) {
+        files.push({
+          name: "generated-meta.txt",
+          type: "meta",
+          content: metaContents.join("\n"),
+        });
+      }
+
+      // Convert class → className
       jsx = jsx.replace(/\bclass=/g, "className=");
 
-      // Convert for to htmlFor
+      // Convert for → htmlFor
       jsx = jsx.replace(/\bfor=/g, "htmlFor=");
 
-      // Convert inline styles from string to object format
+      // Inline style attributes
       jsx = jsx.replace(/style="([^"]*)"/g, (_match, styleString) => {
         const styleObject = styleString
           .split(";")
-          .filter((style: any) => style.trim())
-          .map((style: any) => {
-            const [property, value] = style
-              .split(":")
-              .map((s: any) => s.trim());
+          .filter((s: string) => s.trim())
+          .map((s: string) => {
+            const [property, value] = s.split(":").map((p) => p.trim());
             if (!property || !value) return "";
-
-            // Convert kebab-case to camelCase
-            const camelCaseProperty = property.replace(/-([a-z])/g, (g: any) =>
-              g[1].toUpperCase()
-            );
-
-            // Handle numeric values
+            const camelCase = property.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
             const processedValue = isNaN(Number(value)) ? `"${value}"` : value;
-
-            return `${camelCaseProperty}: ${processedValue}`;
+            return `${camelCase}: ${processedValue}`;
           })
-          .filter((style: any) => style)
+          .filter(Boolean)
           .join(", ");
-
         return styleObject ? `style={{${styleObject}}}` : "";
       });
 
-      // Handle self-closing tags
+      // Self-closing tags
       const selfClosingTags = [
-        "area",
-        "base",
-        "br",
-        "col",
-        "embed",
-        "hr",
-        "img",
-        "input",
-        "link",
-        "meta",
-        "param",
-        "source",
-        "track",
-        "wbr",
+        "area","base","br","col","embed","hr","img","input","link","meta",
+        "param","source","track","wbr"
       ];
-
       selfClosingTags.forEach((tag) => {
-        // Convert self-closing tags to JSX format
         const regex = new RegExp(`<${tag}([^>]*?)(?<!/)>`, "gi");
         jsx = jsx.replace(regex, `<${tag}$1 />`);
       });
 
-      // Convert HTML comments to JSX comments
+      // HTML comments → JSX comments
       jsx = jsx.replace(/<!--(.*?)-->/g, "{/* $1 */}");
 
-      // Handle boolean attributes
+      // Boolean attributes
       const booleanAttributes = [
-        "checked",
-        "selected",
-        "disabled",
-        "readonly",
-        "multiple",
-        "autofocus",
-        "autoplay",
-        "controls",
-        "defer",
-        "hidden",
-        "loop",
-        "open",
-        "required",
-        "reversed",
+        "checked","selected","disabled","readonly","multiple","autofocus",
+        "autoplay","controls","defer","hidden","loop","open","required","reversed"
       ];
-
       booleanAttributes.forEach((attr) => {
-        // Convert boolean attributes to JSX format
         const regex = new RegExp(`\\b${attr}(?!=)`, "gi");
         jsx = jsx.replace(regex, `${attr}={true}`);
       });
 
-      // Format as a React component
+      // External CSS
+      jsx = jsx.replace(
+        /<link[^>]*rel=["']stylesheet["'][^>]*href=["']([^"']+)["'][^>]*\/?>/gi,
+        (_match, href) => {
+          imports.push(`import '${href}';`);
+          return "";
+        }
+      );
+
+      // External JS
+      jsx = jsx.replace(
+        /<script[^>]*src=["']([^"']+)["'][^>]*>\s*<\/script>/gi,
+        (_match, src) => {
+          imports.push(`import '${src}';`);
+          return "";
+        }
+      );
+
+      // Inline <style>
+      jsx = jsx.replace(/<style[^>]*>([\s\S]*?)<\/style>/gi, (_match, cssContent) => {
+        const fileName = `generated-styles${styleCounter++ || ""}.css`;
+        imports.push(`import './${fileName}';`);
+        files.push({ name: fileName, type: "css", content: cssContent.trim() });
+        return "";
+      });
+
+      // Inline <script>
+      jsx = jsx.replace(/<script[^>]*>([\s\S]*?)<\/script>/gi, (_match, jsContent) => {
+        const fileName = `generated-scripts${scriptCounter++ || ""}.js`;
+        imports.push(`import './${fileName}';`);
+        files.push({ name: fileName, type: "js", content: jsContent.trim() });
+        return "";
+      });
+
+      // Final JSX component
       const componentName = "HtmlComponent";
-      const formattedJsx = `import React from 'react';
+      const jsxCode = `import React from 'react';
+${imports.join("\n")}
 
 const ${componentName} = () => {
   return (
-${jsx
-  .split("\n")
-  .map((line) => "    " + line)
-  .join("\n")}
+${jsx.split("\n").map((l) => "    " + l).join("\n")}
   );
 };
 
 export default ${componentName};`;
 
-      return formattedJsx;
-    } catch (error) {
-      return "Error converting HTML to JSX. Please check your HTML syntax.";
+      return { jsx: jsxCode, files };
+    } catch {
+      return { jsx: "Error converting HTML to JSX. Please check your HTML syntax.", files: [] };
     }
   };
 
-  return {
-    convertHtmlToJsx,
-  };
+  return { convertHtmlToJsx };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,9 +8,12 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      'prettier/standalone': 'prettier/standalone.js',
+      'prettier/parser-babel': 'prettier/parser-babel.js',
     },
   },
   optimizeDeps: {
     exclude: ["lucide-react"],
+    include: ['prettier/standalone','prettier/parser-typescript']
   },
 });


### PR DESCRIPTION
### Description

The current HTML → JSX converter lacked proper handling for full HTML documents. Specifically:
- `<!DOCTYPE html>`, `<html>`, `<head>`, `<body>`, and `<title>` were incorrectly preserved in JSX output, causing invalid components.
- `<meta>` tags were ignored or stripped instead of being surfaced.
- Inline `<style>` and `<script>` blocks were not handled in a developer-friendly way. They were either discarded or commented out.
- Developers had no visibility into inline CSS/JS or <meta> contents once converted.

### Related Issue
Closes - #3 

### Fixes 
- Added parsing rules to remove `<!DOCTYPE>`, `<html>`, `<head>`, `<body>`, and `<title>` while preserving body children in JSX.
- Extracted all `<meta>` tags into a single generated file (generated-meta.txt) and displayed them in the Generated Files section in the UI.
- Extracted inline `<style>` and `<script>` blocks into virtual files (generated-styles.css, generated-scripts.js) displayed below the JSX output with filenames.
- Integrated copy-to-clipboard buttons for JSX and each generated file, using the existing UI components (ToolCard, SectionHeader, Button, Textarea) for consistent styling.
- Ensured external resources (`<link rel="stylesheet"> and <script src="...">`) are correctly transformed into import statements in the JSX output.
- This makes the tool more robust, improves developer visibility, and ensures JSX remains valid React code.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Code refactor or performance improvement
- [ ] Other (please describe):

### Checklist

- [x] I have read the project's [CONTRIBUTING.md](/CONTRIBUTING.md) file.
- [x] I have tested my changes locally.
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.


