### PR TITLE
docs: add macOS build instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ xcode-select --install
 
 **Generate icons (required before packaging):**
 ```bash
-npm run predist:mac
-# This runs "npm run generate:icons"
+npm run generate:icons
 ```
 
 **Build and package** (two options):
@@ -112,7 +111,7 @@ This project is built with:
 - **Tailwind CSS** - Styling
 - **shadcn/ui** - UI components
 
-### Building from Source (Windows)
+### Building from Source
 
 ```bash
 # Clone the repository

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A collection of essential developer utility tools built with Electron, React, an
 ## 📋 System Requirements
 
 - Windows 10 or later (64-bit)
-- macOS 10.13 or later (Intel or Apple Silicon)
+- macOS 10.13 or later (Intel or Apple Silicon) - local builds only
 - No additional dependencies required
 
 ## 📥 Download
@@ -28,7 +28,8 @@ Download the latest version from the [Releases](https://github.com/ahammadabdull
 
 - **Windows Installer**: `DevUtils-Setup-{version}.exe` - Full installer with shortcuts
 - **Windows Portable**: `DevUtils-Portable-{version}.exe` - Portable version, no installation required
-- **macOS DMG**: `DevUtils-{version}.dmg` - macOS disk image installer
+
+**Note**: macOS builds are supported locally only; no official macOS release is available yet.
 
 ## 🔧 Installation
 
@@ -45,46 +46,11 @@ Download the latest version from the [Releases](https://github.com/ahammadabdull
 2. Run the executable directly — no installation needed
 3. The app will run immediately
 
-### macOS Version
-
-1. Download `DevUtils-{version}.dmg`
-2. Open the DMG and drag **DevUtils.app** to your **Applications** folder
-3. Launch DevUtils from Launchpad or Finder
-4. (If prompted by Gatekeeper) Right-click the app → **Open** once to allow unsigned apps
-
-## 🛠️ Development
-
-This project is built with:
-
-- **Electron** - Desktop app framework
-- **React 18** - UI framework
-- **TypeScript** - Type safety
-- **Vite** - Build tool
-- **Tailwind CSS** - Styling
-- **shadcn/ui** - UI components
-
-### Building from Source
-
-```bash
-# Clone the repository
-git clone https://github.com/ahammadabdullah/dev-utils.git
-cd dev-utils
-
-# Install dependencies
-npm install
-
-# Run in development mode
-npm run dev
-npm run electron
-
-# Build for production (Windows)
-npm run build:release
-```
-### Building for macOS
-To build the macOS version of DevUtils, follow these steps:
+### macOS Local Build
+To build DevUtils for macOS locally:
 
 #### Prerequisites
-- You must be on macOS to build macOS artifacts (Apple’s signing and packaging restrictions prevent cross-building from Windows or Linux).
+- You must be on macOS (cannot cross-build from Windows/Linux).
 
 - Node.js (LTS) and npm installed.
 
@@ -92,7 +58,6 @@ To build the macOS version of DevUtils, follow these steps:
 ```bash
 xcode-select --install
 ```
-- (Optional) Apple Developer ID and notarization credentials, if you plan to sign and distribute the app.
 
 #### Commands
 
@@ -107,7 +72,6 @@ npm run predist:mac
 1. Single-step build and package
 ```bash
 npm run build:release:mac
-# # Runs "npm run build" + "npm run dist:mac"
 ```
 
 2. Manual two-step
@@ -117,25 +81,53 @@ npm run dist:mac
 ```
 The packaged `.dmg` file will be available inside the `release/` directory.
 
+Unsigned local builds may show Gatekeeper warnings.
+
 #### Notes
 
-- The macOS build uses electron-builder --mac (as defined in package.json).
+- Builds target both x64 and arm64 architectures
 
-- Targets both x64 and arm64 architectures.
+- Minimum supported macOS version: 10.13
 
-- Minimum supported version: macOS 10.13.
-
-- The build uses Hardened Runtime and config/entitlements.mac.plist for signing.
-
-- Unsigned local builds will still run but may show Gatekeeper warnings.
+- Uses Hardened Runtime and `config/entitlements.mac.plist` for signing
 
 #### Troubleshooting
 
-- If electron-builder throws "macOS builds can only be run on macOS", you are attempting to build on Windows/Linux.
+- Error: "macOS builds can only be run on macOS" → You are attempting to build on Windows/Linux
 
-- If icons or assets are missing, re-run:
+- Missing icons/assets → Re-run:
 ```bash
 npm run predist:mac
+```
+
+
+## 🛠️ Development
+
+This project is built with:
+
+- **Electron** - Desktop app framework
+- **React 18** - UI framework
+- **TypeScript** - Type safety
+- **Vite** - Build tool
+- **Tailwind CSS** - Styling
+- **shadcn/ui** - UI components
+
+### Building from Source (Windows)
+
+```bash
+# Clone the repository
+git clone https://github.com/ahammadabdullah/dev-utils.git
+cd dev-utils
+
+# Install dependencies
+npm install
+
+# Run in development mode
+npm run dev
+npm run electron
+
+# Build for production
+npm run build:release
 ```
 
 ## 🤝 Contributors
@@ -177,5 +169,4 @@ Give a ⭐️ if this project helped you!
 
 ---
 
-**Note:** DevUtils now supports both Windows and macOS builds. Linux support may be added in the future.
-
+**Note:** Only Windows packages are officially released. macOS builds are supported locally but not yet released.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of essential developer utility tools built with Electron, React, an
 ## 📋 System Requirements
 
 - Windows 10 or later (64-bit)
+- macOS 10.13 or later (Intel or Apple Silicon)
 - No additional dependencies required
 
 ## 📥 Download
@@ -25,23 +26,31 @@ A collection of essential developer utility tools built with Electron, React, an
 
 Download the latest version from the [Releases](https://github.com/ahammadabdullah/dev-utils/releases) page:
 
-- **Installer**: `DevUtils-Setup-{version}.exe` - Full installer with shortcuts
-- **Portable**: `DevUtils-Portable-{version}.exe` - Portable version, no installation required
+- **Windows Installer**: `DevUtils-Setup-{version}.exe` - Full installer with shortcuts
+- **Windows Portable**: `DevUtils-Portable-{version}.exe` - Portable version, no installation required
+- **macOS DMG**: `DevUtils-{version}.dmg` - macOS disk image installer
 
 ## 🔧 Installation
 
-### Installer Version
+### Windows Installer Version
 
 1. Download `DevUtils-Setup-{version}.exe`
 2. Run the installer
 3. Follow the installation wizard
-4. Launch DevUtils from Start Menu or Desktop shortcut
+4. Launch DevUtils from the Start Menu or Desktop shortcut
 
-### Portable Version
+### Windows Portable Version
 
 1. Download `DevUtils-Portable-{version}.exe`
-2. Run the executable directly - no installation needed
+2. Run the executable directly — no installation needed
 3. The app will run immediately
+
+### macOS Version
+
+1. Download `DevUtils-{version}.dmg`
+2. Open the DMG and drag **DevUtils.app** to your **Applications** folder
+3. Launch DevUtils from Launchpad or Finder
+4. (If prompted by Gatekeeper) Right-click the app → **Open** once to allow unsigned apps
 
 ## 🛠️ Development
 
@@ -68,8 +77,65 @@ npm install
 npm run dev
 npm run electron
 
-# Build for production
+# Build for production (Windows)
 npm run build:release
+```
+### Building for macOS
+To build the macOS version of DevUtils, follow these steps:
+
+#### Prerequisites
+- You must be on macOS to build macOS artifacts (Apple’s signing and packaging restrictions prevent cross-building from Windows or Linux).
+
+- Node.js (LTS) and npm installed.
+
+- Xcode Command Line Tools installed:
+```bash
+xcode-select --install
+```
+- (Optional) Apple Developer ID and notarization credentials, if you plan to sign and distribute the app.
+
+#### Commands
+
+**Generate icons (required before packaging):**
+```bash
+npm run predist:mac
+# This runs "npm run generate:icons"
+```
+
+**Build and package** (two options):
+
+1. Single-step build and package
+```bash
+npm run build:release:mac
+# # Runs "npm run build" + "npm run dist:mac"
+```
+
+2. Manual two-step
+```bash
+npm run build
+npm run dist:mac
+```
+The packaged `.dmg` file will be available inside the `release/` directory.
+
+#### Notes
+
+- The macOS build uses electron-builder --mac (as defined in package.json).
+
+- Targets both x64 and arm64 architectures.
+
+- Minimum supported version: macOS 10.13.
+
+- The build uses Hardened Runtime and config/entitlements.mac.plist for signing.
+
+- Unsigned local builds will still run but may show Gatekeeper warnings.
+
+#### Troubleshooting
+
+- If electron-builder throws "macOS builds can only be run on macOS", you are attempting to build on Windows/Linux.
+
+- If icons or assets are missing, re-run:
+```bash
+npm run predist:mac
 ```
 
 ## 🤝 Contributors
@@ -111,4 +177,5 @@ Give a ⭐️ if this project helped you!
 
 ---
 
-**Note**: This application is currently available for Windows only. macOS and Linux support may be added in the future.
+**Note:** DevUtils now supports both Windows and macOS builds. Linux support may be added in the future.
+


### PR DESCRIPTION
### Description
This pull request updates the `README.md` file to include detailed macOS build instructions.
- **Problem:** The README previously only included build steps for Windows, missing documentation for macOS builds.  
- **Solution:** Added a new "Building for macOS" section describing prerequisites, commands, troubleshooting steps, and packaging notes. 
- **Side Effects:** None. This is a documentation-only update — no code or dependency changes.

### Changes Made
- Added macOS-specific build prerequisites and commands.
- Explained how to generate icons and package `.dmg` files.
- Clarified troubleshooting steps for macOS build errors.
- Updated note at the end to reflect macOS support.

### Related Issue
Fixes #19

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Code refactor or performance improvement
- [ ] Other (please describe):

### Checklist

- [x] I have read the project's [CONTRIBUTING.md](/CONTRIBUTING.md) file.
- [x] I have tested my changes locally (verified build section structure and markdown formatting).
- [x] My code follows the style guidelines of this project.
- [x] I have added comments to my code, particularly in hard-to-understand areas. *(Not applicable — documentation only.)*
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.
